### PR TITLE
DO NOT MERGE: test bed to trigger Konflux builds

### DIFF
--- a/.tekton/determine-image-tag-task-oci-ta.yaml
+++ b/.tekton/determine-image-tag-task-oci-ta.yaml
@@ -40,6 +40,10 @@ spec:
       dnf -y upgrade --nobest
       dnf -y install git make
 
+      git status
+
+      git branch -l
+
       .konflux/scripts/fail-build-if-git-is-dirty.sh
 
       BUILD_TAG="$(git describe --exact-match --tags HEAD)" || echo "Warning: Cannot get tag"

--- a/.tekton/determine-image-tag-task-oci-ta.yaml
+++ b/.tekton/determine-image-tag-task-oci-ta.yaml
@@ -41,4 +41,8 @@ spec:
       dnf -y install git make
 
       .konflux/scripts/fail-build-if-git-is-dirty.sh
+
+      BUILD_TAG="$(git describe --exact-match --tags HEAD)" || echo "Warning: Cannot get tag"
+      export BUILD_TAG
+
       echo -n "$(make --quiet --no-print-directory tag)$(params.TAG_SUFFIX)" | tee "$(results.IMAGE_TAG.path)"

--- a/.tekton/konflux-testing-build.yaml
+++ b/.tekton/konflux-testing-build.yaml
@@ -56,3 +56,7 @@ spec:
 
   pipelineRef:
     name: basic-component-pipeline
+
+  # The pipeline regularly takes >1h to finish.
+  timeouts:
+    pipeline: 4h

--- a/.tekton/konflux-testing-build.yaml
+++ b/.tekton/konflux-testing-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("refs/tags/*")) || (event == "pull_request")
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("refs/tags/*")) || (event == "pull_request" && source_branch.matches("konflux"))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs-testing

--- a/.tekton/konflux-testing-build.yaml
+++ b/.tekton/konflux-testing-build.yaml
@@ -9,9 +9,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-target-branch: "[refs/tags/1.*]"
-    pipelinesascode.tekton.dev/on-event: "[push]"
-    # pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "refs/tags/*"
+    # pipelinesascode.tekton.dev/on-target-branch: "[refs/tags/1.*]"
+    # pipelinesascode.tekton.dev/on-event: "[push]"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch.matches("refs/tags/*")
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs-testing

--- a/.tekton/konflux-testing-build.yaml
+++ b/.tekton/konflux-testing-build.yaml
@@ -10,8 +10,15 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression:
-      (event == "push" && target_branch.matches("refs/tags/*|^(master|release-.*)$")) ||
-      (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
+      (
+        event == "push" && target_branch.matches("refs/tags/*-nightly-*|master")
+      ) || (
+        event == "pull_request" && (
+          (
+            target_branch.matches("master") && source_branch.matches("(konflux|appstudio|rhtap)")
+          ) || body.pull_request.labels.exists(l, l.name == "konflux-build")
+        )
+      )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs-testing

--- a/.tekton/konflux-testing-build.yaml
+++ b/.tekton/konflux-testing-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "refs/tags/*"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs-testing

--- a/.tekton/konflux-testing-build.yaml
+++ b/.tekton/konflux-testing-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("refs/tags/*") || (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)"))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("refs/tags/*")) || (event == "pull_request" && (source_branch.matches("konflux"))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs-testing

--- a/.tekton/konflux-testing-build.yaml
+++ b/.tekton/konflux-testing-build.yaml
@@ -9,9 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    # pipelinesascode.tekton.dev/on-target-branch: "[refs/tags/1.*]"
-    # pipelinesascode.tekton.dev/on-event: "[push]"
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("refs/tags/*"))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("refs/tags/*") || (event == "pull_request" && source_branch.matches("konflux"))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs-testing

--- a/.tekton/konflux-testing-build.yaml
+++ b/.tekton/konflux-testing-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("refs/tags/*") || (event == "pull_request" && source_branch.matches("konflux"))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("refs/tags/*") || (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)"))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs-testing

--- a/.tekton/konflux-testing-build.yaml
+++ b/.tekton/konflux-testing-build.yaml
@@ -9,7 +9,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("refs/tags/*")) || (event == "pull_request" && source_branch.matches("konflux"))
+    pipelinesascode.tekton.dev/on-cel-expression:
+      (event == "push" && target_branch.matches("refs/tags/*|^(master|release-.*)$")) ||
+      (event == "pull_request" && (source_branch.matches("(konflux|appstudio|rhtap)") || body.pull_request.labels.exists(l, l.name == "konflux-build")))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs-testing

--- a/.tekton/konflux-testing-build.yaml
+++ b/.tekton/konflux-testing-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "ref/tags/1.*"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "tm/konflux-trigger"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs-testing

--- a/.tekton/konflux-testing-build.yaml
+++ b/.tekton/konflux-testing-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch == "master") || (event == "pull_request" && (source_branch.contains("rhtap") || source_branch.contains("konflux")))
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "ref/tags/1.*"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs-testing

--- a/.tekton/konflux-testing-build.yaml
+++ b/.tekton/konflux-testing-build.yaml
@@ -11,7 +11,7 @@ metadata:
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression:
       (
-        event == "push" && target_branch.matches("master")
+        event == "push" && target_branch.matches("refs/tags/*-nightly-*|master")
       ) || (
         event == "pull_request" && (
           (

--- a/.tekton/konflux-testing-build.yaml
+++ b/.tekton/konflux-testing-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "tm/konflux-trigger"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs-testing

--- a/.tekton/konflux-testing-build.yaml
+++ b/.tekton/konflux-testing-build.yaml
@@ -9,7 +9,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "refs/tags/*"
+    pipelinesascode.tekton.dev/on-target-branch: "[refs/tags/1.*]"
+    pipelinesascode.tekton.dev/on-event: "[push]"
+    # pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "refs/tags/*"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs-testing

--- a/.tekton/konflux-testing-build.yaml
+++ b/.tekton/konflux-testing-build.yaml
@@ -11,7 +11,7 @@ metadata:
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression:
       (
-        event == "push" && target_branch.matches("refs/tags/*-nightly-*|master")
+        event == "push" && target_branch.matches("master")
       ) || (
         event == "pull_request" && (
           (

--- a/.tekton/konflux-testing-build.yaml
+++ b/.tekton/konflux-testing-build.yaml
@@ -9,7 +9,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     # TODO(ROX-21073): re-enable for all PR branches
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("refs/tags/*")) || (event == "pull_request" && (source_branch.matches("konflux"))
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("refs/tags/*")) || (event == "pull_request")
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs-testing

--- a/.tekton/konflux-testing-build.yaml
+++ b/.tekton/konflux-testing-build.yaml
@@ -11,7 +11,7 @@ metadata:
     # TODO(ROX-21073): re-enable for all PR branches
     # pipelinesascode.tekton.dev/on-target-branch: "[refs/tags/1.*]"
     # pipelinesascode.tekton.dev/on-event: "[push]"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch.matches("refs/tags/*")
+    pipelinesascode.tekton.dev/on-cel-expression: (event == "push" && target_branch.matches("refs/tags/*"))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: acs-testing


### PR DESCRIPTION

* [konflux-testing-build-qrttb](https://console.redhat.com/application-pipeline/workspaces/rh-acs/applications/acs-testing/pipelineruns/konflux-testing-build-qrttb) -> triggered for [commit](https://github.com/tommartensen/konflux-component/commit/23bf662d3b07fde5559fcc4401f8551389330481) to [PR](https://github.com/tommartensen/konflux-component/pull/3), creates 1.1.0-1-g23bf662d3b image
* [konflux-testing-build-thqj7](https://console.redhat.com/application-pipeline/workspaces/rh-acs/applications/acs-testing/pipelineruns/konflux-testing-build-thqj7) -> triggered for [commit](https://github.com/tommartensen/konflux-component/commit/82962378d86428d794630cd5b5a21a4e2f9a3c79) to release-1.0, creates 1.1.0-2-g82962378d8 image
* [konflux-testing-build-smvtn](https://console.redhat.com/application-pipeline/workspaces/rh-acs/applications/acs-testing/pipelineruns/konflux-testing-build-smvtn) -> triggered for [1.0.8](https://github.com/tommartensen/konflux-component/tree/1.0.8), creates 1.0.8 image

BUILD_TAG is used like in [stackrox/stackrox repository](https://github.com/stackrox/stackrox/blob/master/scripts/ci/lib.sh#L1310-L1312) to control the tagging.
* if a tag exists for the revision that is checked out, BUILD_TAG is overwritten and `make tag` will return the tag
* if no tag exists for the revision that is checked out, BUILD_TAG will be empty and `make tag` will return the `git describe` style tag.

We can control the `-fast` suffix with a pipeline parameter or overwrite it for tagged builds. I would actually suggest to set it to `''` on release branches. 

The flow will be like:
* develop as usual on `master`
* diverge `release-x.y` branch from `master` on code freeze, like today.
* (handle suffix, either change pipeline file or have a `am i on master?` switch)
  * for normal commits on release branch: `git describe` style image tags
  * for tagged commits on release branch: image tagged with actual tag
* ❗ with the current expression, nightly tags would also be built on Konflux  